### PR TITLE
Refactor profile management to separate store (#29 #30 #31)

### DIFF
--- a/src/components/base/Avatar.jsx
+++ b/src/components/base/Avatar.jsx
@@ -1,0 +1,15 @@
+// TODO: Implement Avatar component later, when working on Profile or MyVenues page.
+// Require image handling and user data
+export default function Avatar({
+  src,
+  alt = "User avatar",
+  size = "w-24 h-24",
+}) {
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className={`rounded-full border border-gray-300 object-cover ${size}`}
+    />
+  );
+}

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,6 +1,12 @@
 import useAuthStore from "../store/authStore";
 
 export default function useAuth() {
-  const { user, accessToken, isVenueManager } = useAuthStore();
-  return { user, accessToken, isVenueManager };
+  const { user, accessToken, apiKey, isVenueManager } = useAuthStore();
+
+  return {
+    user,
+    accessToken,
+    apiKey,
+    isVenueManager,
+  };
 }

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -17,6 +17,7 @@ export default function Login() {
 
   const navigate = useNavigate();
   const login = useAuthStore((state) => state.login);
+  const setApiKey = useAuthStore((state) => state.setApiKey);
   const [loading, setLoading] = useState(false);
   const [loginError, setLoginError] = useState("");
 
@@ -25,6 +26,7 @@ export default function Login() {
     setLoginError("");
 
     try {
+      // Logg inn
       const response = await axios.post(
         "https://v2.api.noroff.dev/auth/login?_holidaze=true",
         {
@@ -35,9 +37,26 @@ export default function Login() {
 
       const { accessToken, ...user } = response.data.data;
 
-      login({ accessToken, user });
+      // Hent API-nøkkel etter login
+      const apiKeyRes = await axios.post(
+        "https://v2.api.noroff.dev/auth/create-api-key",
+        {},
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      const apiKey = apiKeyRes.data.data.key;
+
+      // Lagre alt
+      login({ accessToken, user, apiKey });
+      setApiKey(apiKey);
       sessionStorage.setItem("accessToken", accessToken);
       sessionStorage.setItem("user", JSON.stringify(user));
+      sessionStorage.setItem("apiKey", apiKey);
       useAuthStore.getState().initAuth();
 
       navigate("/profile");

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,3 +1,80 @@
+import { useEffect, useState } from "react";
+import Avatar from "../components/base/Avatar";
+import Button from "../components/base/Button";
+import ErrorMessage from "../components/base/ErrorMessage";
+import Input from "../components/base/Input";
+import Loader from "../components/base/Loader";
+import useAuth from "../hooks/useAuth";
+import useProfileStore from "../store/profileStore";
+
 export default function Profile() {
-  return <div>Profile</div>;
+  const { user, accessToken, apiKey } = useAuth();
+  const { profile, fetchProfile, updateAvatar, loading, error } =
+    useProfileStore();
+
+  const [avatarUrl, setAvatarUrl] = useState("");
+  const [feedback, setFeedback] = useState({ success: "", error: "" });
+
+  useEffect(() => {
+    if (user?.name && accessToken && apiKey) {
+      fetchProfile({ name: user.name, accessToken, apiKey });
+    }
+  }, [user?.name, accessToken, apiKey, fetchProfile]);
+
+  async function handleAvatarUpdate(e) {
+    e.preventDefault();
+    if (!avatarUrl) return;
+
+    setFeedback({ success: "", error: "" });
+
+    const result = await updateAvatar({
+      name: user.name,
+      avatarUrl,
+      accessToken,
+      apiKey,
+    });
+
+    if (result.success) {
+      setFeedback({ success: "Avatar updated!", error: "" });
+    } else {
+      setFeedback({ error: result.error || "Update failed", success: "" });
+    }
+  }
+
+  if (loading || !profile) return <Loader />;
+  if (error) return <ErrorMessage message={error} />;
+
+  return (
+    <div className="max-w-xl mx-auto mt-8 p-4 bg-white rounded shadow space-y-6">
+      <h1 className="text-2xl font-bold">Profile</h1>
+
+      <div className="flex gap-6 items-center">
+        <Avatar src={profile.avatar?.url} alt={profile.avatar?.alt} />
+        <div>
+          <p className="text-lg font-semibold">{profile.name}</p>
+          <p className="text-sm text-gray-500">{profile.email}</p>
+        </div>
+      </div>
+
+      <form onSubmit={handleAvatarUpdate} className="space-y-4">
+        <Input
+          label="New avatar image URL"
+          value={avatarUrl}
+          onChange={(e) => setAvatarUrl(e.target.value)}
+          placeholder="https://..."
+        />
+
+        <Button type="submit" disabled={loading}>
+          {loading ? "Updating..." : "Update avatar"}
+        </Button>
+
+        {feedback.error && (
+          <p className="text-sm text-red-500">{feedback.error}</p>
+        )}
+        {feedback.success && (
+          <p className="text-sm text-green-600">{feedback.success}</p>
+        )}
+      </form>
+    </div>
+  );
 }

--- a/src/store/authStore.js
+++ b/src/store/authStore.js
@@ -3,21 +3,25 @@ import { create } from "zustand";
 const useAuthStore = create((set) => ({
   user: null,
   accessToken: null,
+  apiKey: null,
   isVenueManager: false,
 
-  login: ({ user, accessToken }) =>
+  login: ({ user, accessToken, apiKey }) =>
     set({
       user,
       accessToken,
+      apiKey,
       isVenueManager: user.venueManager === true,
     }),
 
   logout: () => {
     sessionStorage.removeItem("accessToken");
     sessionStorage.removeItem("user");
+    sessionStorage.removeItem("apiKey");
     set({
       user: null,
       accessToken: null,
+      apiKey: null,
       isVenueManager: false,
     });
   },
@@ -26,26 +30,33 @@ const useAuthStore = create((set) => ({
     try {
       const storedUser = JSON.parse(sessionStorage.getItem("user"));
       const storedToken = sessionStorage.getItem("accessToken");
+      const storedApiKey = sessionStorage.getItem("apiKey");
 
       set({
         user: storedUser || null,
         accessToken: storedToken || null,
+        apiKey: storedApiKey || null,
         isVenueManager: storedUser?.venueManager === true,
       });
     } catch (e) {
-      console.error("[initAuth] Failed to parse sessionStorage user:", e);
+      console.error("[initAuth] Failed to parse sessionStorage:", e);
       set({
         user: null,
         accessToken: null,
+        apiKey: null,
         isVenueManager: false,
       });
     }
+  },
+
+  setApiKey: (apiKey) => {
+    sessionStorage.setItem("apiKey", apiKey);
+    set({ apiKey });
   },
 }));
 
 export default useAuthStore;
 
-// 👇 Gjør tilgjengelig i devtools
 if (import.meta.env.MODE === "development") {
   window.authStore = useAuthStore;
 }

--- a/src/store/profileStore.js
+++ b/src/store/profileStore.js
@@ -1,0 +1,73 @@
+import axios from "axios";
+import { create } from "zustand";
+
+const useProfileStore = create((set) => ({
+  profile: null,
+  loading: false,
+  error: null,
+
+  /**
+   * Henter brukerprofil med venues og bookings
+   */
+  fetchProfile: async ({ name, accessToken, apiKey }) => {
+    set({ loading: true, error: null });
+
+    try {
+      const response = await axios.get(
+        `https://v2.api.noroff.dev/holidaze/profiles/${name}?_venues=true&_bookings=true`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "X-Noroff-API-Key": apiKey,
+          },
+        }
+      );
+
+      set({ profile: response.data.data });
+    } catch (error) {
+      console.error("[profileStore] Failed to fetch profile:", error);
+      set({ error: "Failed to load profile data" });
+    } finally {
+      set({ loading: false });
+    }
+  },
+
+  /**
+   * Oppdaterer avatar med ny URL
+   */
+  updateAvatar: async ({ name, avatarUrl, accessToken, apiKey }) => {
+    set({ loading: true, error: null });
+
+    try {
+      const response = await axios.put(
+        `https://v2.api.noroff.dev/holidaze/profiles/${name}`,
+        {
+          avatar: {
+            url: avatarUrl,
+            alt: `${name}'s avatar`,
+          },
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "X-Noroff-API-Key": apiKey,
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      set({ profile: response.data.data });
+      return { success: true };
+    } catch (error) {
+      console.error("[profileStore] Failed to update avatar:", error);
+      const message =
+        error?.response?.data?.errors?.[0]?.message ||
+        "Could not update avatar";
+      return { success: false, error: message };
+    } finally {
+      set({ loading: false });
+    }
+  },
+}));
+
+export default useProfileStore;


### PR DESCRIPTION
### Refactor profile and registration flows into separate stores (#29 #30 #31)

- Created Profile Page showing avatar and basic user info  
- Enabled avatar update with form, feedback and sync to store  
- Created `profileStore.js` to manage profile state (fetch + update)  
- Refactored `Profile.jsx` to use profileStore (cleaner + scalable)  
- Removed profile logic from `authStore.js` and `useAuth.js` (single responsibility)  
- Fully refactored `Register.jsx`:  
  - Validates email, password, confirm-password, venue manager  
  - Registers new user (POST /auth/register)  
  - Logs in user immediately after  
  - Fetches API key (POST /auth/create-api-key)  
  - Stores all data in Zustand + sessionStorage  
- Confirmed flow works end-to-end: register → login → profile loaded with avatar + bookings  
- Closes #29, #30, #31
